### PR TITLE
Adding files mapping feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,18 +46,34 @@ The `annotation.csv` has a following structure (with no header):
 
 ## Tutorial
 
-1. **Prepare the dataset:** To get started, create a folder with the following file structure:
+1. **Prepare the dataset:** 
 
-    ```
-    - image1.nii.gz
-    - image1_mask.nii.gz
-    - image2.nii.gz
-    - image2_mask.nii.gz
-    ...
-    ```
-    The images should be in NIfTI format (`.nii.gz`), with corresponding segmentation masks labeled `_mask.nii.gz`.
+    - **Option 1 - Provide a mappings.csv file**
 
-An example dataset of T1w brain scans and their corresponding brain segmentations is provided in the `example_data` folder with already reviewed images. You can use this dataset to test the extension. If you want to review the images yourself, you can delete the `annotations.csv` file and start the review process from scratch.
+      Create a `mappings.csv` file in the inputs folder specifying the `img_path` and the respective `mask_path`. Se bellow an example of the content of this file:
+        ```
+        img_path,mask_path
+        data/1.nrrd,/path/to/respective/1_mask.nii.gz
+        data/2.nii.gz,/path/to/respective/2_mask.nii.gz
+        ...
+        ```
+      > :warning: The name of the file must be `mappings.csv` and the first line must contain the column names `img_path` and `mask_path`.
+
+    - **Option 2 - Structure the input data folder (only works for nifti)**
+
+      To get started, create a folder with the following file structure:
+
+        ```
+        - image1.nii.gz
+        - image1_mask.nii.gz
+        - image2.nii.gz
+        - image2_mask.nii.gz
+        ...
+        ```
+
+        The images should be in NIfTI format (`.nii.gz`), with corresponding segmentation masks labeled `_mask.nii.gz`.
+
+    An example dataset of T1w brain scans and their corresponding brain segmentations is provided in the `example_data` folder with already reviewed images. You can use this dataset to test the extension. If you want to review the images yourself, you can delete the `annotations.csv` file and start the review process from scratch.
 
 2. **Load the dataset into 3D Slicer:** After starting 3D Slicer, open `File -> Add Data` from the main menu, then select the folder containing the images and masks and press `OK`. After loading, you will see how many images are loaded under the _Checked_ status. If the path is opened for the first time, an `annotations.csv` file will be created in the same folder. This file will contain the results of the rating and will be automatically updated after each rating. Additionally, the `annotations.csv` file allows you to restore the annotation process in case of a crash or if there are too many images to rate in one session.
 

--- a/SegmentationReview/SegmentationReview.py
+++ b/SegmentationReview/SegmentationReview.py
@@ -181,16 +181,27 @@ class SegmentationReviewWidget(ScriptedLoadableModuleWidget, VTKObservationMixin
         else:
             self.current_df = pd.DataFrame(columns=['file', 'annotation'])
             self.current_index = 0
-        
+
         # count the number of files in the directory
-        for file in os.listdir(directory):
-            if ".nii" in file and "_mask" not in file:
-                self.n_files+=1
-                if os.path.exists(directory+"/"+file.split(".")[0]+"_mask.nii.gz"):
-                    self.nifti_files.append(directory+"/"+file)
-                    self.segmentation_files.append(directory+"/"+file.split(".")[0]+"_mask.nii.gz")
+        if os.path.exists(directory+"/mappings.csv"):
+            self.mappings = pd.read_csv(directory+"/mappings.csv")
+            print("Loaded mappings between files and masks")
+            for img, mask in zip(self.mappings["img_path"], self.mappings["mask_path"]):
+                if os.path.exists(img) and os.path.exists(mask):
+                    self.nifti_files.append(img)
+                    self.segmentation_files.append(mask)
+                    self.n_files+=1
                 else:
-                    print("No mask for file: ", file)
+                    print("File(s) not found: ", [i for i in [img, mask] if not os.path.exists(i)])
+        else:
+            for file in os.listdir(directory):
+                if ".nii" in file and "_mask" not in file:
+                    self.n_files+=1
+                    if os.path.exists(directory+"/"+file.split(".")[0]+"_mask.nii.gz"):
+                        self.nifti_files.append(directory+"/"+file)
+                        self.segmentation_files.append(directory+"/"+file.split(".")[0]+"_mask.nii.gz")
+                    else:
+                        print("No mask for file: ", file)
         self.ui.status_checked.setText("Checked: "+ str(self.current_index) + " / "+str(self.n_files-1))
          
         # load first file with mask

--- a/SegmentationReview/SegmentationReview.py
+++ b/SegmentationReview/SegmentationReview.py
@@ -154,18 +154,18 @@ class SegmentationReviewWidget(ScriptedLoadableModuleWidget, VTKObservationMixin
     
     def overwrite_mask_clicked(self):
         # overwrite self.segmentEditorWidget.segmentationNode()
-        print("Saved segmentation",self.segmentation_files[self.current_index].split("/")[-1].split(".")[0]+"_upd.nii.gz")
         #segmentation_node = slicer.mrmlScene.GetFirstNodeByClass('vtkMRMLSegmentationNode')
 
         # Get the file path where you want to save the segmentation node
         file_path = self.directory+"/t.seg.nrrd"
         # Save the segmentation node to file as nifti
-        file_path_nifti = self.directory+"/"+self.segmentation_files[self.current_index].split("/")[-1].split(".")[0]+"_upd.nii.gz"
+        file_path_nifti = self.segmentation_files[self.current_index].split(".")[0]+"_upd.nii.gz"
         # Save the segmentation node to file
         slicer.util.saveNode(self.segmentation_node, file_path)
         
         img = sitk.ReadImage(file_path)
         sitk.WriteImage(img, file_path_nifti)
+        print("Saved segmentation",file_path_nifti)
     def onAtlasDirectoryChanged(self, directory):
         if self.volume_node:
             slicer.mrmlScene.RemoveNode(self.volume_node)
@@ -223,7 +223,7 @@ class SegmentationReviewWidget(ScriptedLoadableModuleWidget, VTKObservationMixin
             
         self.likert_scores.append([self.current_index, likert_score, self.ui.comment.toPlainText()])
         # append data frame to CSV file
-        data = {'file': [self.nifti_files[self.current_index].split("/")[-1]], 'annotation': [likert_score],'comment': [self.ui.comment.toPlainText()]}
+        data = {'file': [self.nifti_files[self.current_index]], 'annotation': [likert_score],'comment': [self.ui.comment.toPlainText()]}
         df = pd.DataFrame(data)   
         df.to_csv(self.directory+"/annotations.csv", mode='a', index=False, header=False)
 

--- a/SegmentationReview/SegmentationReview.py
+++ b/SegmentationReview/SegmentationReview.py
@@ -166,6 +166,10 @@ class SegmentationReviewWidget(ScriptedLoadableModuleWidget, VTKObservationMixin
         img = sitk.ReadImage(file_path)
         sitk.WriteImage(img, file_path_nifti)
         print("Saved segmentation",file_path_nifti)
+
+    def _is_valid_extension(self, path):
+        return any(path.endswith(i) for i in [".nii", ".nii.gz", ".nrrd"])
+
     def onAtlasDirectoryChanged(self, directory):
         if self.volume_node:
             slicer.mrmlScene.RemoveNode(self.volume_node)
@@ -187,7 +191,7 @@ class SegmentationReviewWidget(ScriptedLoadableModuleWidget, VTKObservationMixin
             self.mappings = pd.read_csv(directory+"/mappings.csv")
             print("Loaded mappings between files and masks")
             for img, mask in zip(self.mappings["img_path"], self.mappings["mask_path"]):
-                if os.path.exists(img) and os.path.exists(mask):
+                if os.path.exists(img) and os.path.exists(mask) and self._is_valid_extension(img) and self._is_valid_extension(mask):
                     self.nifti_files.append(img)
                     self.segmentation_files.append(mask)
                     self.n_files+=1


### PR DESCRIPTION
The current implementation is constrained to .nii.gz files, and it requires the user to re-structure their files. This feature allows the user to provide a mappings.csv file, where the user specifies the paths to their images and respective masks. The extension will look for the mappings.csv file in the input_path if it finds one it uses the valid paths on it, otherwise if no mappings.csv is provided, the previous behavior is used. Note that this new feature also allows users to review their .nrrd files.